### PR TITLE
Replace "Variational Bayes" by "Variational Inference" in chapter 5 ; numerical methods section

### DIFF
--- a/05_Bayesian_inference.ipynb
+++ b/05_Bayesian_inference.ipynb
@@ -272,7 +272,7 @@
     "  * Hamiltonian Monte Carlo (HMC)\n",
     "  * No-U-Turn sampler (NUTS)\n",
     "  * further variants such as SGHMC, LDHMC, etc\n",
-    "- Variational Bayes\n",
+    "- Variational Inference\n",
     "- Approximate Bayesian Computation (ABC)\n",
     "- Particle filters\n",
     "- Laplace approximation\n",


### PR DESCRIPTION
In this PR, I'm fixing the wording issue mentioned in this image.

![issue](https://github.com/user-attachments/assets/f2e0dcd9-e2bb-47fc-bc1e-e61ce593ba1d)
