### PR TITLE
Update the wget link in the Bayesian_workflow notebook

### DIFF
--- a/11_Bayesian_workflow.ipynb
+++ b/11_Bayesian_workflow.ipynb
@@ -487,7 +487,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -574,7 +574,11 @@
    "source": [
     "#!wget -O Howell1.csv https://github.com/elizavetasemenova/prob-epi/blob/main/data/Howell1.csv\n",
     "\n",
-    "df = pd.read_csv('data/Howell1.csv', sep=\";\")\n",
+    "!wget -O Howell1.csv https://raw.githubusercontent.com/elizavetasemenova/prob-epi/main/data/Howell1.csv\n",
+    "\n",
+    "df = pd.read_csv('Howell1.csv', delimiter=';')\n",
+    "df.columns = df.columns.str.replace('\"', '')\n",
+    "# df = pd.read_csv('data/Howell1.csv', sep=\";\")\n",
     "df.head()"
    ]
   },


### PR DESCRIPTION
Access the Raw File: GitHub repositories provide a "Raw" link for direct access to files. This link points to the actual file rather than the HTML page.